### PR TITLE
Deploy ghp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,9 @@
 #
 version: 2
 jobs:
-  build:
+  build-job:
     docker:
-      # specify the version you desire here
       - image: circleci/node:7.10
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
 
     working_directory: ~/repo-website
 
@@ -32,6 +26,30 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
-      # run tests!
+
       - run: yarn test
+  deploy-job:
+    docker:
+      - image: circleci/node:7.10
+
+    working_directory: ~/repo-website
+
+    steps:
+      - run:
+          name: Install some stuff
+          command: yarn install
+      - run:
+          name: Deploy if tests pass and branch is Master
+          command: ./scripts/deploy-ghpages.sh build
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build-job
+      - deploy-job:
+          requires:
+            - build-job
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,3 @@ workflows:
       - deploy-job:
           requires:
             - build-job
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,19 @@ jobs:
     working_directory: ~/repo-website
 
     steps:
+      - checkout
+
       - run:
-          name: Install some stuff
+          name: Install packages
           command: yarn install
+
+      - run:
+          name: Build bundle
+          command: yarn build
+
       - run:
           name: Deploy if tests pass and branch is Master
-          command: ./scripts/deploy-ghpages.sh build
+          command: pwd && ls -la && .circleci/deploy-ghpages.sh build
 
 workflows:
   version: 2

--- a/.circleci/deploy-ghpages.sh
+++ b/.circleci/deploy-ghpages.sh
@@ -20,7 +20,6 @@ git config --global user.name "$GH_NAME" > /dev/null 2>&1
 git init
 git remote add --fetch origin "$remote"
 
-
 # switch into the the gh-pages branch
 if git rev-parse --verify origin/gh-pages > /dev/null 2>&1
 then
@@ -33,7 +32,7 @@ else
 fi
 
 # copy over or recompile the new site
-#cp -a "../${siteSource}/." .
+cp -a "../build/." .
 
 # stage any changes and new files
 git add -A

--- a/scripts/deploy-ghpages.sh
+++ b/scripts/deploy-ghpages.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# ideas used from https://gist.github.com/motemen/8595451
+
+# Based on https://github.com/eldarlabs/ghpages-deploy-script/blob/master/scripts/deploy-ghpages.sh
+# Used with their MIT license https://github.com/eldarlabs/ghpages-deploy-script/blob/master/LICENSE
+
+# abort the script if there is a non-zero error
+set -e
+
+# show where we are on the machine
+pwd
+remote=$(git config remote.origin.url)
+
+# make a directory to put the gp-pages branch
+mkdir gh-pages-branch
+cd gh-pages-branch
+# now lets setup a new repo so we can update the gh-pages branch
+git config --global user.email "$GH_EMAIL" > /dev/null 2>&1
+git config --global user.name "$GH_NAME" > /dev/null 2>&1
+git init
+git remote add --fetch origin "$remote"
+
+
+# switch into the the gh-pages branch
+if git rev-parse --verify origin/gh-pages > /dev/null 2>&1
+then
+    git checkout gh-pages
+    # delete any old site as we are going to replace it
+    # Note: this explodes if there aren't any, so moving it here for now
+    git rm -rf .
+else
+    git checkout --orphan gh-pages
+fi
+
+# copy over or recompile the new site
+#cp -a "../${siteSource}/." .
+
+# stage any changes and new files
+git add -A
+# now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
+git commit --allow-empty -m "Deploy to GitHub pages [ci skip]"
+# and push, but send any output to /dev/null to hide anything sensitive
+git push --force --quiet origin gh-pages
+# go back to where we started and remove the gh-pages git repo we made and used
+# for deployment
+cd ..
+rm -rf gh-pages-branch
+
+echo "Finished Deployment!"


### PR DESCRIPTION
Fixes #4 

This change enables a build that hits CircleCI to build a production bundle, then deploy it to Github Pages. There are additional changes required to the configuration of CircleCI and the deployment script to enable deployment to the cityofzion.github.io repo.